### PR TITLE
handle missing "httpVersion" in response

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/harpy/response.py
+++ b/harpy/response.py
@@ -9,7 +9,7 @@ class Response(object):
 
         self.status = self.raw["status"]
         self.status_text = self.raw["statusText"]
-        self.http_version = self.raw["httpVersion"]
+        self.http_version = self.raw.get("httpVersion", None)
 
         self.cookies = []
         for c in self.raw["cookies"]:


### PR DESCRIPTION
This is necessary if you want to parse Chrome Dev Tools' HAR, which doesn't provide a version
